### PR TITLE
jQuery 1.6.4 $.ajax Transport support

### DIFF
--- a/envjs/xhr.js
+++ b/envjs/xhr.js
@@ -552,7 +552,8 @@ XMLHttpRequest.prototype = {
     readyState: 0,
     responseText: "",
     status: 0,
-    statusText: ""
+    statusText: "",
+    withCredentials: false
 };
 
 }(/*XMLHttpREquest*/));

--- a/src/xhr/xmlhttprequest.js
+++ b/src/xhr/xmlhttprequest.js
@@ -212,7 +212,8 @@ XMLHttpRequest.prototype = {
     readyState: 0,
     responseText: "",
     status: 0,
-    statusText: ""
+    statusText: "",
+    withCredentials: false
 };
 
 }(/*XMLHttpREquest*/));


### PR DESCRIPTION
In jQuery 1.6.4, the Ajax Transport checks if the request is "crossDomain" and, if so, requires jQuery.support.cors to be true:

``` javascript
if ( !s.crossDomain || jQuery.support.cors ) {
```

CORS support checks for the existence of the 'withCredentials' property (default boolean false), which is not present in Envjs.

I added it in this commit: https://github.com/vanm/env-js/commit/2f485c0ea5706354a1bbc53ddc6d5d894746a79f

Since most requests in our test suite are classified as "crossDomain" by jQuery, this is required to get $.ajax requests working properly.
