### PR TITLE
Add support for ownerDocument.activeElement (focus/blur)

### DIFF
--- a/envjs/html.js
+++ b/envjs/html.js
@@ -942,6 +942,9 @@ var  __reset__ = function(element){
 
 //LABEL, INPUT, SELECT, TEXTAREA, and BUTTON
 var __focus__ = function(element){
+    if (element.ownerDocument.activeElement){
+      element.ownerDocument.activeElement = element;
+    }
     var event = new Event('HTMLEvents');
     event.initEvent("focus", false, false);
     element.dispatchEvent(event);
@@ -950,6 +953,9 @@ var __focus__ = function(element){
 
 //LABEL, INPUT, SELECT, TEXTAREA, and BUTTON
 var __blur__ = function(element){
+    if (element === element.ownerDocument.activeElement){
+      element.ownerDocument.activeElement = null;
+    }
     var event = new Event('HTMLEvents');
     event.initEvent("blur", false, false);
     element.dispatchEvent(event);

--- a/envjs/html.js
+++ b/envjs/html.js
@@ -942,7 +942,7 @@ var  __reset__ = function(element){
 
 //LABEL, INPUT, SELECT, TEXTAREA, and BUTTON
 var __focus__ = function(element){
-    if (element.ownerDocument.activeElement){
+    if (element.ownerDocument){
       element.ownerDocument.activeElement = element;
     }
     var event = new Event('HTMLEvents');

--- a/src/html/htmlevents.js
+++ b/src/html/htmlevents.js
@@ -124,6 +124,9 @@ var  __reset__ = function(element){
 
 //LABEL, INPUT, SELECT, TEXTAREA, and BUTTON
 var __focus__ = function(element){
+    if (element.ownerDocument){
+      element.ownerDocument.activeElement = element;
+    }
     var event = new Event('HTMLEvents');
     event.initEvent("focus", false, false);
     element.dispatchEvent(event);
@@ -132,6 +135,9 @@ var __focus__ = function(element){
 
 //LABEL, INPUT, SELECT, TEXTAREA, and BUTTON
 var __blur__ = function(element){
+    if (element === element.ownerDocument.activeElement){
+      element.ownerDocument.activeElement = null;
+    }
     var event = new Event('HTMLEvents');
     event.initEvent("blur", false, false);
     element.dispatchEvent(event);


### PR DESCRIPTION
jQuery 1.6.4 added a ':focus' filter that relies on ownerDocument.activeElement.  This branch sets and clears the property on focus/blur, enabling support for the ':focus' selector.
